### PR TITLE
Bug 1313154 - enrich mimetypes with json extension too. r=jlund

### DIFF
--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -7,6 +7,7 @@ MIME_MAP = {
     '.bz2': 'application/octet-stream',
     '.checksums': 'text/plain',
     '.dmg': 'application/x-iso9660-image',
+    '.json': 'application/json',
     '.mar': 'application/octet-stream',
     '.xpi': 'application/zip',
     '.apk': 'application/vnd.android.package-archive',


### PR DESCRIPTION
@lundjordan 

1. Few errors made the (usigned artifacts) BM build to fail. At a second look in the logs, it failed with the following error:

2016-11-04T16:57:44     INFO -   File "/builds/beetmoverworker/lib/python3.5/site-packages/botocore/validate.py", line 270, in serialize_to_request
2016-11-04T16:57:44     INFO -     raise ParamValidationError(report=report.generate_report())
2016-11-04T16:57:44     INFO - botocore.exceptions.ParamValidationError: Parameter validation failed:
2016-11-04T16:57:44     INFO - Invalid type for parameter ContentType, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
2016-11-04T16:57:45     INFO - exit code: 1

2. All files were correctly copied to S3 but oddly these three JSON files:

    json:
      artifact: {{ locale_prefix }}target.json
      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.json
    mozinfo:
      artifact: {{ locale_prefix }}target.mozinfo.json
      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.mozinfo.json
    test_packages:
      artifact: {{ locale_prefix }}target.test_packages.json
      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.test_packages.json

Reproducing the error both locally and on the beetmoverworker side, one can notice mimetypes types do not contain json application type in the content-type. See below:

(Pdb) n
> /tools/python35/lib/python3.5/mimetypes.py(143)guess_type()
-> if ext in types_map:
(Pdb) pp types_map
{'... '.ief': 'image/ief',
 '.jpe': 'image/jpeg',
 '.jpeg': 'image/jpeg',
 '.jpg': 'image/jpeg',
 '.js': 'application/javascript',
 ...
 '.zip': 'application/zip'}

Adding this before we start beetmoving should solve the problem.