### PR TITLE
Bug 1313154 - adapt beetmoverscript to cope with desktop nightlies.

### DIFF
--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -116,7 +116,7 @@ def enrich_balrog_manifest(context, path, locale, destinations):
         url_replacements = [['http://archive.mozilla.org/pub, http://download.cdn.mozilla.net/pub']]
 
     return {
-        "tc_fennec_nightly": True,
+        "tc_nightly": True,
 
         "completeInfo": [{
             "hash": get_hash(path, hash_type=props["hashType"]),

--- a/beetmoverscript/templates/fennec_nightly_en_us_multi_signed.yml
+++ b/beetmoverscript/templates/fennec_nightly_en_us_multi_signed.yml
@@ -10,4 +10,8 @@ mapping:
       artifact: {{ locale_prefix }}target.apk
       s3_key: {{ locale_prefix  }}fennec-{{ version }}.{{ locale }}.android-arm.apk
       update_balrog_manifest: {{ update_balrog_manifest }}
+    # Bug 1316124 - TODO
+    #checksums:
+      #artifact: {{ locale_prefix }}target.checksums
+      #s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.checksums
 {% endfor %}

--- a/beetmoverscript/templates/fennec_nightly_en_us_multi_unsigned.yml
+++ b/beetmoverscript/templates/fennec_nightly_en_us_multi_unsigned.yml
@@ -5,53 +5,52 @@ mapping:
 {% for locale in ['multi', 'en-US'] %}
   {{ locale }}:
   {% set locale_prefix = 'en-US/' if locale == 'en-US' else '' %}
-    # Bug 1316124
-    #checksums:
-      #artifact: {{ locale_prefix }}target.checksums
-      #s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.checksums
     common:
       artifact: {{ locale_prefix }}target.common.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.common.tests.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.common.tests.zip
     cppunittest:
       artifact: {{ locale_prefix }}target.cppunittest.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.cppunittest.tests.zip
-    crashreporter:
-      artifact: {{ locale_prefix }}target.crashreporter-symbols.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.crashreporter-symbols.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.cppunittest.tests.zip
     json:
       artifact: {{ locale_prefix }}target.json
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.json
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.json
     mochitest:
       artifact: {{ locale_prefix }}target.mochitest.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.mochitest.tests.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.mochitest.tests.zip
     mozinfo:
       artifact: {{ locale_prefix }}target.mozinfo.json
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.mozinfo.json
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.mozinfo.json
     reftest:
       artifact: {{ locale_prefix }}target.reftest.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.reftest.tests.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.reftest.tests.zip
     talos:
       artifact: {{ locale_prefix }}target.talos.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.talos.tests.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.talos.tests.zip
     test_packages:
       artifact: {{ locale_prefix }}target.test_packages.json
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.test_packages.json
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.test_packages.json
     txt:
       artifact: {{ locale_prefix }}target.txt
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.txt
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.txt
     webplatform:
       artifact: {{ locale_prefix }}target.web-platform.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.web-platform.tests.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.web-platform.tests.zip
     xpcshell:
       artifact: {{ locale_prefix }}target.xpcshell.tests.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.xpcshell.tests.zip
-    jsshell:
-      artifact: {{ locale_prefix }}target.jsshell.zip
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android.arm.jsshell.zip
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm.xpcshell.tests.zip
     info:
       artifact: {{ locale_prefix }}target_info.txt
-      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android_info.txt
+      s3_key: {{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-arm_info.txt
     bouncer:
       artifact: {{ locale_prefix }}bouncer.apk
       s3_key: {{ locale_prefix }}bouncer.apk
+    mozharness:
+      artifact: {{ locale_prefix }}mozharness.zip
+      s3_key: {{ locale_prefix }}mozharness.zip
+    robocop:
+      artifact: {{ locale_prefix }}robocop.apk
+      s3_key: {{ locale_prefix }}robocop.apk
+    jsshell:
+      artifact: {{ locale_prefix }}target.jsshell.zip
+      s3_key: {{ locale_prefix }}jsshell-android-arm.zip
 {% endfor %}

--- a/beetmoverscript/templates/firefox_nightly_en_us_signed.yml
+++ b/beetmoverscript/templates/firefox_nightly_en_us_signed.yml
@@ -8,7 +8,16 @@ mapping:
     package:
       artifact: target.tar.bz2
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.tar.bz2
+    complete_mar:
+      artifact: update/target.complete.mar
+      s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.complete.mar
       update_balrog_manifest: true
+    checksums:
+      artifact: target.checksums
+      s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.checksums
+    checksums_asc:
+      artifact: target.checksums.asc
+      s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.checksums.asc
 
   {% endif %}
 

--- a/beetmoverscript/templates/firefox_nightly_en_us_unsigned.yml
+++ b/beetmoverscript/templates/firefox_nightly_en_us_unsigned.yml
@@ -4,10 +4,6 @@ mapping:
   # common deliverables
 {% for locale in ['en-US'] %}
   {{ locale }}:
-    # Bug 1316124
-    #checksums:
-      #artifact: target.checksums
-      #s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.checksums
     common:
       artifact: target.common.tests.zip
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.common.tests.zip
@@ -17,9 +13,6 @@ mapping:
     crashreporter:
       artifact: target.crashreporter-symbols.zip
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.crashreporter-symbols.zip
-    #crashreporter_full:
-      #artifact: target.crashreporter-symbols-full.zip
-      #s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.crashreporter-symbols-full.zip
     json:
       artifact: target.json
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.json
@@ -50,10 +43,6 @@ mapping:
     info:
       artifact: target_info.txt
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}_info.txt
-    # TODO: CMAR to be removed once we have the signed one
-    complete_mar:
-      artifact: update/target.complete.mar
-      s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.complete.mar
     jsshell:
       artifact: target.jsshell.zip
       s3_key: jsshell-{{ platform }}.zip
@@ -63,20 +52,21 @@ mapping:
     xpi:
       artifact: {{ platform }}/xpi/firefox-{{ version }}.{{ locale }}.langpack.xpi
       s3_key: firefox-{{ version }}.{{ locale }}.langpack.xpi
+    mar_tools_mar:
+      artifact: host/bin/mar
+      s3_key: mar-tools/{{ stage_platform }}/mar
+    mar_tools_mbdiff:
+      artifact: host/bin/mbsdiff
+      s3_key: mar-tools/{{ stage_platform }}/mbsdiff
 
   {% if platform in ["linux-i686", "linux-x86_64"] %}
     sdk:
       artifact: target.sdk.tar.bz2
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.sdk.tar.bz2
-    mar_tools_mar:
-      artifact: host/bin/mar
-      s3_key: mar
-    mar_tools_mbdiff:
-      artifact: host/bin/mbsdiff
-      s3_key: mbsdiff
-    #gtest:
-      #artifact: target.gtest.tests.zip
-      #s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.gtest.tests.zip
+    # Bug 1316125 - TODO
+    #sdk_asc:
+      #artifact: target.sdk.tar.bz2.asc
+      #s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.sdk.tar.bz2.asc
 
   {% endif %}
 


### PR DESCRIPTION
@lundjordan r?

Obs:
1. For "tc_fennec_nightly" => "tc_nightly" change, I'll adapt accordingly https://github.com/mozilla-releng/balrogscript/blob/master/bin/balrogworker.py#L179 as soon as this lands.

2. I re-double-checked the files under our staging bucket against http://archive.mozilla.org/pub/mobile/nightly/latest-mozilla-central-android-api-15/ and made the corrections.

3. The same for desktop nightlies from our staging bucket against http://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/ and made the corrections.

4. Tweaked the checksums accordinly in both Fennec/Firefox, since we now have them on the signing tasks side.

5. Changed to CMAR from tar.bz2 for the file to be sent to Balrog.

6. I left few TODOs in the code for later on, reminders for us to add those files. 

7. Removed some of the artifacts as we have a bug 1316125 tracking for missing artifacts just before Tier-1.