### PR TITLE
bug 1333895 - reduce max concurrent connections

### DIFF
--- a/beetmoverscript/test/fake_config.json
+++ b/beetmoverscript/test/fake_config.json
@@ -1,7 +1,7 @@
 {
     "work_dir": "beetmoverscript/test/test_work_dir",
     "artifact_dir": "beetmoverscript/test/test_artifact_dir",
-    "aiohttp_max_connections": 20,
+    "aiohttp_max_connections": 10,
     "checksums_digests": ["sha512", "md5", "sha1", "sha256"],
     "verbose": true,
     "schema_file": "beetmoverscript/data/beetmover_task_schema.json",

--- a/config_example.json
+++ b/config_example.json
@@ -3,7 +3,7 @@
     "artifact_dir": "artifact_dir",
     "verbose": true,
     "schema_file": "/path/to/beetmoverscript/beetmoverscript/data/beetmover_task_schema.json",
-    "aiohttp_max_connections": 20,
+    "aiohttp_max_connections": 10,
     "checksums_digests": ["sha512", "md5", "sha1", "sha256"],
     "template_files": {
         "firefox_nightly": "/path/to/beetmoverscript/beetmoverscript/templates/firefox_nightly.yml",


### PR DESCRIPTION
This is good for new installs; we'll also need a puppet patch for prod installs.