### PR TITLE
add path to upload log status

### DIFF
--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -160,7 +160,7 @@ async def put(context, url, headers, abs_filename, session=None):
     session = session or context.session
     with open(abs_filename, "rb") as fh:
         async with session.put(url, data=fh, headers=headers, compress=False) as resp:
-            log.info(resp.status)
+            log.info("put {}: {}".format(abs_filename, resp.status))
             response_text = await resp.text()
             log.info(response_text)
             if resp.status not in (200, 204):


### PR DESCRIPTION
When we upload many artifacts in parallel, we often see many log lines with a status line but no sign of which artifact was uploaded.  By adding the path to the log, we'll be able to trace this easier.