### PR TITLE
Bug 1336754 (Bugzilla) - Changed application/zip to application/x-xpinstall

### DIFF
--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -10,7 +10,7 @@ MIME_MAP = {
     '.dmg': 'application/x-iso9660-image',
     '.json': 'application/json',
     '.mar': 'application/octet-stream',
-    '.xpi': 'application/zip',
+    '.xpi': 'application/x-xpinstall',
     '.apk': 'application/vnd.android.package-archive',
 }
 STAGE_PLATFORM_MAP = {


### PR DESCRIPTION
Changed application/zip to application/x-xpinstall for direct install of langpacks in archive.mozilla.org

Referring to bugzilla (Bug 1336754) -
https://bugzilla.mozilla.org/show_bug.cgi?id=1336754