### PR TITLE
Bug 1343649 - fix build_number and version within various action types. r=jlorenzo

### DIFF
--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -56,3 +56,9 @@ RESTRICTED_BUCKET_PATHS = {
         'pub/mobile/releases',
     ]
 }
+
+# actions that imply actual releases, hence the need of `build_number` and
+# `version`
+RELEASE_ACTIONS = (
+    'push-to-candidates',
+)

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -7,7 +7,7 @@ from beetmoverscript.test import (get_fake_valid_task, get_fake_valid_config,
                                   get_fake_balrog_props, get_fake_checksums_manifest)
 from beetmoverscript.utils import (generate_beetmover_manifest, get_hash,
                                    write_json, generate_beetmover_template_args,
-                                   write_file, shipping_a_release)
+                                   write_file, is_action_a_release_shipping)
 from beetmoverscript.constants import HASH_BLOCK_SIZE
 
 
@@ -116,6 +116,6 @@ def test_beetmover_template_args_generation():
 @pytest.mark.parametrize("release", [
     'push-to-candidates',
 ])
-def test_shipping_a_release(non_release, release):
-    assert shipping_a_release(non_release) is False
-    assert shipping_a_release(release) is True
+def test_if_action_is_a_release_shipping(non_release, release):
+    assert is_action_a_release_shipping(non_release) is False
+    assert is_action_a_release_shipping(release) is True

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -1,12 +1,13 @@
-import tempfile
 import json
+import pytest
+import tempfile
 
 from scriptworker.context import Context
 from beetmoverscript.test import (get_fake_valid_task, get_fake_valid_config,
                                   get_fake_balrog_props, get_fake_checksums_manifest)
 from beetmoverscript.utils import (generate_beetmover_manifest, get_hash,
                                    write_json, generate_beetmover_template_args,
-                                   write_file)
+                                   write_file, shipping_a_release)
 from beetmoverscript.constants import HASH_BLOCK_SIZE
 
 
@@ -105,3 +106,16 @@ def test_beetmover_template_args_generation():
     template_args = generate_beetmover_template_args(context)
 
     assert template_args['template_key'] == 'fake_nightly_repacks'
+
+
+@pytest.mark.parametrize("non_release", [
+    'push-to-nightly',
+    'push-to-releases',
+    'push-to-staging',
+])
+@pytest.mark.parametrize("release", [
+    'push-to-candidates',
+])
+def test_shipping_a_release(non_release, release):
+    assert shipping_a_release(non_release) is False
+    assert shipping_a_release(release) is True

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -51,7 +51,7 @@ def write_file(path, contents):
         fh.write(contents)
 
 
-def shipping_a_release(action):
+def is_action_a_release_shipping(action):
     """Function to return boolean if we're shipping a release as opposed to a
     nightly release or something else. Does that by checking the action type.
     Currently the only action that supports release-releases is
@@ -77,7 +77,7 @@ def generate_beetmover_template_args(context):
         "platform": release_props["platform"],
     }
 
-    if shipping_a_release(context.action):
+    if is_action_a_release_shipping(context.action):
         tmpl_args["build_number"] = task['payload']['build_number']
         tmpl_args["version"] = task['payload']['version']
 

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -10,7 +10,7 @@ import jinja2
 import yaml
 
 from beetmoverscript.constants import (HASH_BLOCK_SIZE, STAGE_PLATFORM_MAP,
-                                       TEMPLATE_KEY_PLATFORMS)
+                                       TEMPLATE_KEY_PLATFORMS, RELEASE_ACTIONS)
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +51,16 @@ def write_file(path, contents):
         fh.write(contents)
 
 
+def shipping_a_release(action):
+    """Function to return boolean if we're shipping a release as opposed to a
+    nightly release or something else. Does that by checking the action type.
+    Currently the only action that supports release-releases is
+    `push-to-candidates` for which we need to enforce the `version` and
+    `build_number` grabbing.
+    """
+    return action in RELEASE_ACTIONS
+
+
 def generate_beetmover_template_args(context):
     task = context.task
     release_props = context.release_props
@@ -67,7 +77,7 @@ def generate_beetmover_template_args(context):
         "platform": release_props["platform"],
     }
 
-    if 'release' in context.bucket:
+    if shipping_a_release(context.action):
         tmpl_args["build_number"] = task['payload']['build_number']
         tmpl_args["version"] = task['payload']['version']
 


### PR DESCRIPTION
@escapewindow @JohanLorenzo 

Latest jamun-based staging Fennec beetmover tasks fail because of `jinja2.exceptions.UndefinedError: 'build_number' is undefined`. More logs can be found here[1].

That is because initially we chained the `version` and `build_number` to the bucket scope, instead of the action scope. So far we could have only extracted and enriched the context with `version` and `build_number` if the release scopes were present. This failed on `jamun` as we're using `dep` bucket scopes and `push-to-candidates` action scopes. 

This PR is changing this behavior so that it's no longer chained to bucket scopes but instead to action scopes, so that any release scheduled on try, or jamun or any other low-level branch can actually be generated as long as a `build_number` and `version` are provided within the task payload. 

Currently, the only action that needs and ships a release is the `push-to-candidates`. For `push-to-nightly` we don't need them as we have `buildId` and other stuff whilst `push-to-releases` is for now done via relpro mozharness beetmover. In the near/future future we might enrich the list, but for now, it can stay as it is in my opinion.

Requesting this PR change + a beetmoverscript bump in puppet to upgrade the beetmoverworkers. This is currently affecting only jamun. It will work if we use the releasetasks graph gen for a real Fennec as the scopes there will default to 'release'.

[1]: https://public-artifacts.taskcluster.net/c5Usw0ETRhid-2WL0X9dog/0/public/logs/live_backing.log