### PR TITLE
Bug 1366404 - Add templates for AArch64

### DIFF
--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -23,6 +23,7 @@ STAGE_PLATFORM_MAP = {
 TEMPLATE_KEY_PLATFORMS = defaultdict(lambda: "firefox", {
     "android-api-15": "fennec",
     "android-x86": "fennecx86",
+    "android-aarch64": "fennecaarch64",
     "android-api-15-old-id": "fennec",
     "android-x86-old-id": "fennecx86",
 })

--- a/beetmoverscript/templates/fennecaarch64_candidates.yml
+++ b/beetmoverscript/templates/fennecaarch64_candidates.yml
@@ -1,0 +1,118 @@
+---
+metadata:
+    name: "Beet Mover Manifest"
+    description: "Maps {{ product }} artifacts to pretty names for the en-US and multi locale"
+    owner: "release@mozilla.com"
+
+s3_bucket_path: pub/mobile/candidates/{{ version }}-candidates/build{{ build_number }}/
+
+mapping:
+{% for locale in ['multi', 'en-US'] %}
+  {{ locale }}:
+  {% set update_balrog_manifest = True if locale == 'multi' else False %}
+
+    bouncer.apk:
+      s3_key: bouncer.apk
+      destinations:
+        - {{ platform }}/{{ locale }}/bouncer.apk
+    target.apk:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.apk
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.apk
+      update_balrog_manifest: {{ update_balrog_manifest }}
+    target.checksums:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.checksums
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.checksums
+    target.checksums.asc:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.checksums.asc
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.checksums.asc
+    target.common.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.common.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.common.tests.zip
+    target.cppunittest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.cppunittest.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.cppunittest.tests.zip
+    target.crashreporter-symbols-full.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols-full.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols-full.zip
+    target.crashreporter-symbols.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols.zip
+    target.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.json
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.json
+    target.mochitest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.mochitest.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.mochitest.tests.zip
+    target.mozinfo.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.mozinfo.json
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.mozinfo.json
+    target.reftest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.reftest.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.reftest.tests.zip
+    target.talos.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.talos.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.talos.tests.zip
+    target.awsy.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.awsy.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.awsy.tests.zip
+    target.test_packages.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.test_packages.json
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.test_packages.json
+    target.txt:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.txt
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.txt
+    target.web-platform.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.web-platform.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.web-platform.tests.zip
+    target.xpcshell.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.xpcshell.tests.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64.xpcshell.tests.zip
+    target_info.txt:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64_info.txt
+      destinations:
+        - {{ platform }}/{{ locale }}/fennec-{{ version }}.{{ locale }}.android-aarch64_info.txt
+        - {{ platform }}/{{ locale }}/{{ platform }}_info.txt
+        - {{ platform }}_info.txt
+    target.jsshell.zip:
+      s3_key: jsshell-android-aarch64.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/jsshell-android-aarch64.zip
+    mozharness.zip:
+      s3_key:  mozharness.zip
+      destinations:
+        - {{ platform }}/{{ locale }}/mozharness.zip
+    robocop.apk:
+      s3_key: robocop.apk
+      destinations:
+        - {{ platform }}/{{ locale }}/robocop.apk
+
+    {% if locale == 'en-US' %}
+    mar:
+      s3_key: mar
+      destinations:
+        - host/bin/mar
+    mbsdiff:
+      s3_key: mbsdiff
+      destinations:
+        - host/bin/mbsdiff
+
+    {% endif %}
+
+{% endfor %}

--- a/beetmoverscript/templates/fennecaarch64_nightly.yml
+++ b/beetmoverscript/templates/fennecaarch64_nightly.yml
@@ -1,0 +1,128 @@
+---
+metadata:
+    name: "Beet Mover Manifest"
+    description: "Maps {{ product }} Nightly artifacts to pretty names for the en-US and multi locale"
+    owner: "release@mozilla.com"
+
+s3_bucket_path: pub/mobile/nightly/
+
+mapping:
+{% for locale in ['multi', 'en-US'] %}
+  {{ locale }}:
+  {% set locale_prefix = 'en-US/' if locale == 'en-US' else '' %}
+  {% set update_balrog_manifest = True if locale == 'multi' else False %}
+
+    bouncer.apk:
+      s3_key: bouncer.apk
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}bouncer.apk
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}bouncer.apk
+    target.apk:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.apk
+      destinations:
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.apk
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.apk
+      update_balrog_manifest: {{ update_balrog_manifest }}
+    target.checksums:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.checksums
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.checksums
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.checksums
+    target.checksums.asc:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.checksums.asc
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.checksums.asc
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.checksums.asc
+    target.common.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.common.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.common.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.common.tests.zip
+    target.cppunittest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.cppunittest.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.cppunittest.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.cppunittest.tests.zip
+    target.crashreporter-symbols-full.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols-full.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols-full.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols-full.zip
+    target.crashreporter-symbols.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.crashreporter-symbols.zip
+    target.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.json
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.json
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.json
+    target.mochitest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.mochitest.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.mochitest.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.mochitest.tests.zip
+    target.mozinfo.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.mozinfo.json
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.mozinfo.json
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.mozinfo.json
+    target.reftest.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.reftest.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.reftest.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.reftest.tests.zip
+    target.talos.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.talos.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.talos.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.talos.tests.zip
+    target.awsy.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.awsy.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.awsy.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.awsy.tests.zip
+
+    target.test_packages.json:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.test_packages.json
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.test_packages.json
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.test_packages.json
+    target.txt:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.txt
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.txt
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.txt
+    target.web-platform.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.web-platform.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.web-platform.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.web-platform.tests.zip
+    target.xpcshell.tests.zip:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64.xpcshell.tests.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.xpcshell.tests.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64.xpcshell.tests.zip
+    target_info.txt:
+      s3_key: fennec-{{ version }}.{{ locale }}.android-aarch64_info.txt
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64_info.txt
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}fennec-{{ version }}.{{ locale }}.android-aarch64_info.txt
+    target.jsshell.zip:
+      s3_key: jsshell-android-aarch64.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}jsshell-android-aarch64.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}jsshell-android-aarch64.zip
+    mozharness.zip:
+      s3_key: mozharness.zip
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}mozharness.zip
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}mozharness.zip
+    robocop.apk:
+      s3_key: robocop.apk
+      destinations:
+        - latest-{{ branch }}-{{ platform }}/{{ locale_prefix }}robocop.apk
+        - {{ upload_date }}-{{ branch }}-{{ platform }}/{{ locale_prefix }}robocop.apk
+
+{% endfor %}


### PR DESCRIPTION
Add templates for uploading the new Fennec AArch64 Nightly. The templates are copied from the corresponding x86 templates, with the architecture name replaced.

I think that's all that's needed, but I'm not sure how to actually test that.