### PR TITLE
bug 1364765 - retry on any exception.

### DIFF
--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -221,6 +221,7 @@ async def upload_to_s3(context, s3_key, path):
     url = s3.generate_presigned_url('put_object', api_kwargs, ExpiresIn=1800, HttpMethod='PUT')
 
     await retry_async(put, args=(context, url, headers, path),
+                      retry_exceptions=(Exception, ),
                       kwargs={'session': context.session})
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         0,
         5,
-        5
+        6
     ],
-    "version_string": "0.5.5"
+    "version_string": "0.5.6"
 }


### PR DESCRIPTION
We're currently dying on uncaught exceptions in `retry_async`: https://bugzilla.mozilla.org/show_bug.cgi?id=1364765

I would have limited this to only aiohttp exceptions, but the one highlighted in that bug is a `
concurrent.futures._base.CancelledError`.  `Exception` is a catch-all.

@MihaiTabara , @lundjordan can one of you take a look?