### PR TITLE
Bug 1381508 - part 2: Upload win en-US installers to l10n dirs

### DIFF
--- a/beetmoverscript/templates/firefox_nightly.yml
+++ b/beetmoverscript/templates/firefox_nightly.yml
@@ -185,11 +185,13 @@ mapping:
       destinations:
         - {{ upload_date }}-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer-stub.exe
         - latest-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer-stub.exe
+        - latest-{{ branch }}-l10n/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer-stub.exe
     target.installer.exe:
       s3_key: installer.exe
       destinations:
         - {{ upload_date }}-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer.exe
         - latest-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer.exe
+        - latest-{{ branch }}-l10n/firefox-{{ version }}.{{ locale }}.{{ platform }}.installer.exe
     target.stylo-bindings.zip:
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.stylo-bindings.zip
       destinations:


### PR DESCRIPTION
Follow up #73. It turns out every locale but en-US is uploaded. This patch fixes it.