### PR TITLE
Bug 1396797 Support for partials in manifest

### DIFF
--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -141,9 +141,9 @@ async def move_beets(context, artifacts_to_beetmove, manifest):
     # and collate it now.
     for locale in context.raw_balrog_manifest:
         balrog_entry = enrich_balrog_manifest(context, locale)
-        balrog_entry['completeInfo'] = context.balrog_manifest[locale]['completeInfo']
-        if 'partialInfo' in context.balrog_manifest[locale]:
-            balrog_entry['partialInfo'] = context.balrog_manifest[locale]['partialInfo']
+        balrog_entry['completeInfo'] = context.raw_balrog_manifest[locale]['completeInfo']
+        if 'partialInfo' in context.raw_balrog_manifest[locale]:
+            balrog_entry['partialInfo'] = context.raw_balrog_manifest[locale]['partialInfo']
         context.balrog_manifest.append(balrog_entry)
 
 

--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -53,6 +53,10 @@ async def push_to_nightly(context):
     # this manifest to submit release blob info (e.g. mar filename, size, etc)
     context.balrog_manifest = list()
 
+    # Used as a staging area to generate balrog_manifest, so that all the
+    # completes and partials for a release end up in the same data structure
+    context.raw_balrog_manifest = dict()
+
     # the checksums manifest is written and uploaded as an artifact which is
     # used by a subsequent signing task and again by another beetmover task to
     # upload it to S3
@@ -120,18 +124,31 @@ async def move_beets(context, artifacts_to_beetmove, manifest):
                             manifest['mapping'][locale][artifact]['destinations']]
 
             balrog_manifest = manifest['mapping'][locale][artifact].get('update_balrog_manifest')
+            # For partials
+            from_buildid = manifest['mapping'][locale][artifact].get('from_buildid')
             beets.append(
                 asyncio.ensure_future(
                     move_beet(context, source, destinations, locale=locale,
                               update_balrog_manifest=balrog_manifest,
+                              from_buildid=from_buildid,
                               artifact_pretty_name=artifact_pretty_name)
                 )
             )
     await raise_future_exceptions(beets)
 
+    # Fix up balrog manifest. We need an entry with both completes and
+    # partials, which is why we store up the data from each moved beet
+    # and collate it now.
+    for locale in context.raw_balrog_manifest:
+        balrog_entry = enrich_balrog_manifest(context, locale)
+        balrog_entry['completeInfo'] = context.balrog_manifest[locale]['completeInfo']
+        if 'partialInfo' in context.balrog_manifest[locale]:
+            balrog_entry['partialInfo'] = context.balrog_manifest[locale]['partialInfo']
+        context.balrog_manifest.append(balrog_entry)
+
 
 async def move_beet(context, source, destinations, locale,
-                    update_balrog_manifest, artifact_pretty_name):
+                    update_balrog_manifest, from_buildid, artifact_pretty_name):
     await retry_upload(context=context, destinations=destinations, path=source)
 
     if context.checksums.get(artifact_pretty_name) is None:
@@ -141,17 +158,36 @@ async def move_beet(context, source, destinations, locale,
         context.checksums[artifact_pretty_name]['size'] = get_size(source)
 
     if update_balrog_manifest:
-        context.balrog_manifest.append(
-            enrich_balrog_manifest(context, artifact_pretty_name, locale, destinations)
-        )
+        context.raw_balrog_manifest.setdefault(locale, {})
+        if from_buildid:
+            component = 'partialInfo'
+        else:
+            component = 'completeInfo'
+        context.raw_balrog_manifest[locale].setdefault(component, [])
+        context.raw_balrog_manifest[locale][component].append(generate_balrog_info(context, artifact_pretty_name,
+                                                                                   locale, destinations, from_buildid))
 
 
-def enrich_balrog_manifest(context, artifact_pretty_name, locale, destinations):
+def generate_balrog_info(context, artifact_pretty_name, locale, destinations, from_buildid=None):
     release_props = context.release_props
     checksums = context.checksums
 
     url = "{prefix}/{s3_key}".format(prefix="https://archive.mozilla.org",
                                      s3_key=destinations[0])
+
+    data = {
+        "hash": checksums[artifact_pretty_name][release_props["hashType"]],
+        "size": checksums[artifact_pretty_name]['size'],
+        "url": url
+    }
+    if from_buildid:
+        data["from_buildid"] = from_buildid
+    return data
+
+
+def enrich_balrog_manifest(context, locale):
+    release_props = context.release_props
+
     url_replacements = []
     if release_props["branch"] in RELEASE_BRANCHES:
         url_replacements.append(['http://archive.mozilla.org/pub',
@@ -159,12 +195,6 @@ def enrich_balrog_manifest(context, artifact_pretty_name, locale, destinations):
 
     return {
         "tc_nightly": True,
-        "completeInfo": [{
-            "hash": checksums[artifact_pretty_name][release_props["hashType"]],
-            "size": checksums[artifact_pretty_name]['size'],
-            "url": url
-        }],
-
         "appName": release_props["appName"],
         "appVersion": release_props["appVersion"],
         "branch": release_props["branch"],

--- a/beetmoverscript/templates/firefox_nightly.yml
+++ b/beetmoverscript/templates/firefox_nightly.yml
@@ -213,5 +213,7 @@ mapping:
         - {{ upload_date }}-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
         - latest-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
         - latest-{{ branch }}-l10n/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
+      update_balrog_manifest: true
+      from_buildid: {{ from_buildid }}
   {% endfor %}
 {% endfor %}

--- a/beetmoverscript/templates/firefox_nightly_repacks.yml
+++ b/beetmoverscript/templates/firefox_nightly_repacks.yml
@@ -83,4 +83,6 @@ mapping:
       destinations:
         - {{ upload_date }}-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
         - latest-{{ branch }}-l10n/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
+      update_balrog_manifest: true
+      from_buildid: {{ from_buildid }}
   {% endfor %}

--- a/beetmoverscript/test/fake_beetmover_manifest.yml
+++ b/beetmoverscript/test/fake_beetmover_manifest.yml
@@ -16,11 +16,14 @@ mapping:
       destinations:
         - {{ upload_date }}-{{ branch }}-fake/{{ locale_prefix  }}fake-{{ version }}.{{ locale }}.target_info.txt
         - latest-{{ branch }}-fake/{{ locale_prefix  }}fake-{{ version }}.{{ locale }}.target_info.txt
+      update_balrog_manifest: true
     target.txt:
       s3_key: fake-{{ version }}.{{ locale }}.target.txt
       destinations:
         - {{ upload_date }}-{{ branch }}-fake/{{ locale_prefix  }}fake-{{ version }}.{{ locale }}.target.txt
         - latest-{{ branch }}-fake/{{ locale_prefix  }}fake-{{ version }}.{{ locale }}.target.txt
+      from_buildid: 19991231235959
+      update_balrog_manifest: true
     target.mozinfo.json:
       s3_key: fake-{{ version }}.{{ locale }}.target.mozinfo.json
       destinations:

--- a/beetmoverscript/test/test_script.py
+++ b/beetmoverscript/test/test_script.py
@@ -90,6 +90,7 @@ def test_move_beets(event_loop):
     context.release_props['platform'] = context.release_props['stage_platform']
     context.bucket = 'nightly'
     context.action = 'push-to-nightly'
+    context.raw_balrog_manifest = dict()
     context.artifacts_to_beetmove = get_upstream_artifacts(context)
     manifest = generate_beetmover_manifest(context)
 
@@ -122,7 +123,7 @@ def test_move_beets(event_loop):
     actual_destinations = []
 
     async def fake_move_beet(context, source, destinations, locale,
-                             update_balrog_manifest, artifact_pretty_name):
+                             update_balrog_manifest, artifact_pretty_name, from_buildid):
         actual_sources.append(source)
         actual_destinations.append(destinations)
 
@@ -141,6 +142,7 @@ def test_move_beet(event_loop):
     context.task = get_fake_valid_task()
     context.checksums = dict()
     context.balrog_manifest = list()
+    context.raw_balrog_manifest = dict()
     context.release_props = get_fake_balrog_props()["properties"]
     context.release_props['platform'] = context.release_props['stage_platform']
     locale = "sample-locale"
@@ -169,11 +171,12 @@ def test_move_beet(event_loop):
     with mock.patch('beetmoverscript.script.retry_upload', fake_retry_upload):
         event_loop.run_until_complete(
             move_beet(context, target_source, target_destinations, locale,
-                      update_balrog_manifest=True, artifact_pretty_name=pretty_name)
+                      update_balrog_manifest=True, artifact_pretty_name=pretty_name,
+                      from_buildid=None)
         )
     assert expected_upload_args == actual_upload_args
     for k in expected_balrog_manifest.keys():
-        assert (context.balrog_manifest[0]['completeInfo'][0][k] ==
+        assert (context.raw_balrog_manifest[locale]['completeInfo'][0][k] ==
                 expected_balrog_manifest[k])
 
 

--- a/beetmoverscript/test/test_script.py
+++ b/beetmoverscript/test/test_script.py
@@ -8,7 +8,7 @@ from yarl import URL
 
 from beetmoverscript.script import (setup_mimetypes, setup_config, put,
                                     move_beets, move_beet, async_main,
-                                    main)
+                                    main, enrich_balrog_manifest)
 from beetmoverscript.task import get_upstream_artifacts
 from beetmoverscript.test import get_fake_valid_config, get_fake_valid_task, get_fake_balrog_props
 from beetmoverscript.utils import generate_beetmover_manifest
@@ -82,6 +82,29 @@ def test_put_failure(event_loop, fake_session_500):
         )
 
 
+def test_enrich_balrog_manifest():
+    context = Context()
+    context.release_props = get_fake_balrog_props()["properties"]
+    context.release_props['platform'] = context.release_props['stage_platform']
+
+    expected_data = {
+        'tc_nightly': True,
+        'appName': context.release_props['appName'],
+        'appVersion': context.release_props['appVersion'],
+        'branch': context.release_props['branch'],
+        'buildid': context.release_props['buildid'],
+        'extVersion': context.release_props['appVersion'],
+        'hashType': context.release_props['hashType'],
+        'locale': 'sample-locale',
+        'platform': context.release_props['stage_platform'],
+        'url_replacements': [['http://archive.mozilla.org/pub',
+                              'http://download.cdn.mozilla.net/pub']],
+    }
+
+    data = enrich_balrog_manifest(context, 'sample-locale')
+    assert data == expected_data
+
+
 def test_move_beets(event_loop):
     context = Context()
     context.config = get_fake_valid_config()
@@ -91,6 +114,7 @@ def test_move_beets(event_loop):
     context.bucket = 'nightly'
     context.action = 'push-to-nightly'
     context.raw_balrog_manifest = dict()
+    context.balrog_manifest = list()
     context.artifacts_to_beetmove = get_upstream_artifacts(context)
     manifest = generate_beetmover_manifest(context)
 
@@ -119,6 +143,41 @@ def test_move_beets(event_loop):
          'pub/mobile/nightly/latest-mozilla-central-fake/en-US/fake-99.0a1.en-US.target.test_packages.json'],
     ]
 
+    expected_balrog_manifest = [
+        {
+            'tc_nightly': True,
+            'appName': 'Fake',
+            'appVersion': '99.0a1',
+            'branch': 'mozilla-central',
+            'buildid': '20990205110000',
+            'extVersion': '99.0a1',
+            'hashType': 'sha512',
+            'locale': 'en-US',
+            'platform': 'android-api-15',
+            'url_replacements': [['http://archive.mozilla.org/pub', 'http://download.cdn.mozilla.net/pub']],
+            'completeInfo': [
+                {
+                    'hash': 'dummyhash',
+                    'size': 123456,
+                    'url': 'pub/mobile/nightly/2016/09/2016-09-01-16-26-14-mozilla-central-fake/en-US/fake-99.0a1.en-US.target.mozinfo.json'
+                },
+                {
+                    'hash': 'dummyhash',
+                    'size': 123456,
+                    'url': 'pub/mobile/nightly/2016/09/2016-09-01-16-26-14-mozilla-central-fake/en-US/fake-99.0a1.en-US.target_info.txt'
+                }
+            ],
+            'partialInfo': [
+                {
+                    'from_buildid': 19991231235959,
+                    'hash': 'dummyhash',
+                    'size': 123456,
+                    'url': 'pub/mobile/nightly/2016/09/2016-09-01-16-26-14-mozilla-central-fake/en-US/fake-99.0a1.en-US.target.txt'
+                }
+            ],
+        }
+    ]
+
     actual_sources = []
     actual_destinations = []
 
@@ -126,6 +185,21 @@ def test_move_beets(event_loop):
                              update_balrog_manifest, artifact_pretty_name, from_buildid):
         actual_sources.append(source)
         actual_destinations.append(destinations)
+        if update_balrog_manifest:
+
+            data = {
+                "hash": 'dummyhash',
+                "size": 123456,
+                "url": destinations[0]
+            }
+            if from_buildid:
+                data["from_buildid"] = from_buildid
+                component = 'partialInfo'
+            else:
+                component = 'completeInfo'
+            context.raw_balrog_manifest.setdefault(locale, {})
+            context.raw_balrog_manifest[locale].setdefault(component, [])
+            context.raw_balrog_manifest[locale][component].append(data)
 
     with mock.patch('beetmoverscript.script.move_beet', fake_move_beet):
         event_loop.run_until_complete(
@@ -134,6 +208,7 @@ def test_move_beets(event_loop):
 
     assert sorted(expected_sources) == sorted(actual_sources)
     assert sorted(expected_destinations) == sorted(actual_destinations)
+    assert context.balrog_manifest == expected_balrog_manifest
 
 
 def test_move_beet(event_loop):
@@ -177,6 +252,17 @@ def test_move_beet(event_loop):
     assert expected_upload_args == actual_upload_args
     for k in expected_balrog_manifest.keys():
         assert (context.raw_balrog_manifest[locale]['completeInfo'][0][k] ==
+                expected_balrog_manifest[k])
+
+    expected_balrog_manifest['from_buildid'] = '19991231235959'
+    with mock.patch('beetmoverscript.script.retry_upload', fake_retry_upload):
+        event_loop.run_until_complete(
+            move_beet(context, target_source, target_destinations, locale,
+                      update_balrog_manifest=True, artifact_pretty_name=pretty_name,
+                      from_buildid='19991231235959')
+        )
+    for k in expected_balrog_manifest.keys():
+        assert (context.raw_balrog_manifest[locale]['partialInfo'][0][k] ==
                 expected_balrog_manifest[k])
 
 


### PR DESCRIPTION
The outbound manifest, used by balrog scriptworker, needs to
have information about partials added.

It's unwise to add a partial if there's no related complete,
so this involves a refactor so that instead of directly
populating context.balrog_manifest, we instead fill a
staging area with details about the files we have uploaded.

Once all uploads are done, we generate the balrog manifest
to be of the expected form.

    [
        {
            "tc_nightly": true,
            "extVersion": "",
            "appVersion": "",
            "completeInfo": [
                {
                    "hash": "...",
                    "url": "...",
                    "size": 
                }
            ],
            "partialInfo": [
                {
                    "hash": "...",
                    "url": "...",
                    "size": 
                }
            ],
            "platform": "",
            "buildid": "",
            "locale": "",
            "branch": "",
            "url_replacements": [],
            "hashType": "sha512",
            "appName": "Firefox"
        }
    ]