### PR TITLE
fix fennec beetmover candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] - 2017-10-24
+### Added
+- added `PROMOTION_ACTIONS` and `is_promotion_action`
+
+### Changed
+- Renamed `is_action_a_release_shipping` to `is_release_action`
+- removed `push-to-candidates` from `RELEASE_ACTIONS`
+
+### Fixed
+- Only use the release task schema for `RELEASE_ACTIONS`; this was breaking fennec beetmover candidates
+
 ## [2.0.0] - 2017-10-23
 ### Added
 - 100% test coverage

--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -78,7 +78,6 @@ RESTRICTED_BUCKET_PATHS = {
 # `version`
 PROMOTION_ACTIONS = (
     'push-to-candidates',
-    'push-to-releases',
 )
 RELEASE_ACTIONS = (
     'push-to-releases',

--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -76,8 +76,11 @@ RESTRICTED_BUCKET_PATHS = {
 
 # actions that imply actual releases, hence the need of `build_number` and
 # `version`
-RELEASE_ACTIONS = (
+PROMOTION_ACTIONS = (
     'push-to-candidates',
+    'push-to-releases',
+)
+RELEASE_ACTIONS = (
     'push-to-releases',
 )
 

--- a/beetmoverscript/task.py
+++ b/beetmoverscript/task.py
@@ -8,7 +8,7 @@ from beetmoverscript.constants import (IGNORED_UPSTREAM_ARTIFACTS,
                                        INITIAL_RELEASE_PROPS_FILE,
                                        RESTRICTED_BUCKET_PATHS)
 
-from beetmoverscript.utils import write_json, write_file, is_action_a_release_shipping
+from beetmoverscript.utils import write_json, write_file, is_release_action
 from scriptworker.exceptions import ScriptWorkerTaskException
 
 log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def validate_task_schema(context):
     """Perform a schema validation check against taks definition"""
     schema_file = context.config['schema_file']
     action = get_task_action(context.task, context.config)
-    if is_action_a_release_shipping(action):
+    if is_release_action(action):
         schema_file = context.config['release_schema_file']
     with open(schema_file) as fh:
         task_schema = json.load(fh)

--- a/beetmoverscript/test/test_task.py
+++ b/beetmoverscript/test/test_task.py
@@ -36,7 +36,7 @@ def test_validate_task(context):
     validate_task_schema(context)
 
     # release validation
-    context.task['scopes'] = ["project:releng:beetmover:action:push-to-candidates"]
+    context.task['scopes'] = ["project:releng:beetmover:action:push-to-releases"]
     context.task['payload'] = {
         'product': 'fennec',
         'build_number': 1,

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -133,13 +133,13 @@ def test_beetmover_template_args_generation_release(context):
     assert template_args == expected_template_args
 
 
-# is_release_action is_promotion_aciton {{{1
+# is_release_action is_promotion_action {{{1
 @pytest.mark.parametrize("action,release,promotion", ((
     'push-to-nightly', False, False,
 ), (
     'push-to-candidates', False, True,
 ), (
-    'push-to-releases', True, True,
+    'push-to-releases', True, False,
 )))
 def test_is_action_release_or_promotion(action, release, promotion):
     assert is_release_action(action) is release

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -8,7 +8,7 @@ from beetmoverscript.test import (context, get_fake_valid_task,
 import beetmoverscript.utils as butils
 from beetmoverscript.utils import (generate_beetmover_manifest, get_hash,
                                    write_json, generate_beetmover_template_args,
-                                   write_file, is_action_a_release_shipping,
+                                   write_file, is_release_action, is_promotion_action,
                                    get_release_props, get_partials_props,
                                    matches_exclude, get_candidates_prefix,
                                    get_releases_prefix)
@@ -133,17 +133,17 @@ def test_beetmover_template_args_generation_release(context):
     assert template_args == expected_template_args
 
 
-# is_action_a_release_shipping {{{1
-@pytest.mark.parametrize("non_release", [
-    'push-to-nightly',
-])
-@pytest.mark.parametrize("release", [
-    'push-to-candidates',
-    'push-to-releases',
-])
-def test_if_action_is_a_release_shipping(non_release, release):
-    assert is_action_a_release_shipping(non_release) is False
-    assert is_action_a_release_shipping(release) is True
+# is_release_action is_promotion_aciton {{{1
+@pytest.mark.parametrize("action,release,promotion", ((
+    'push-to-nightly', False, False,
+), (
+    'push-to-candidates', False, True,
+), (
+    'push-to-releases', True, True,
+)))
+def test_is_action_release_or_promotion(action, release, promotion):
+    assert is_release_action(action) is release
+    assert is_promotion_action(action) is promotion
 
 
 # get_release_props {{{1

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -9,8 +9,10 @@ import pprint
 import re
 import yaml
 
-from beetmoverscript.constants import (HASH_BLOCK_SIZE, STAGE_PLATFORM_MAP,
-                                       TEMPLATE_KEY_PLATFORMS, RELEASE_ACTIONS)
+from beetmoverscript.constants import (
+    HASH_BLOCK_SIZE, STAGE_PLATFORM_MAP, TEMPLATE_KEY_PLATFORMS,
+    RELEASE_ACTIONS, PROMOTION_ACTIONS
+)
 
 log = logging.getLogger(__name__)
 
@@ -51,11 +53,18 @@ def write_file(path, contents):
         fh.write(contents)
 
 
-def is_action_a_release_shipping(action):
-    """Function to return boolean if we're shipping a release as opposed to a
+def is_release_action(action):
+    """Function to return boolean if we're publishing a release as opposed to a
     nightly release or something else. Does that by checking the action type.
     """
     return action in RELEASE_ACTIONS
+
+
+def is_promotion_action(action):
+    """Function to return boolean if we're promoting a release as opposed to a
+    nightly or something else. Does that by checking the action type.
+    """
+    return action in PROMOTION_ACTIONS
 
 
 def generate_beetmover_template_args(context):
@@ -76,7 +85,7 @@ def generate_beetmover_template_args(context):
         "partials": get_partials_props(task),
     }
 
-    if is_action_a_release_shipping(context.action):
+    if is_promotion_action(context.action):
         tmpl_args["build_number"] = task['payload']['build_number']
         tmpl_args["version"] = task['payload']['version']
 

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -85,7 +85,7 @@ def generate_beetmover_template_args(context):
         "partials": get_partials_props(task),
     }
 
-    if is_promotion_action(context.action):
+    if is_promotion_action(context.action) or is_release_action(context.action):
         tmpl_args["build_number"] = task['payload']['build_number']
         tmpl_args["version"] = task['payload']['version']
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        2,
+        3,
         0,
         0
     ],
-    "version_string": "2.0.0"
+    "version_string": "3.0.0"
 }


### PR DESCRIPTION
I debated lumping push-to-candidates with push-to-releases, and it looks
like the schema change busted push-to-candidates. This patch separates
them back out.