### PR TITLE
Bug 1405622 - Stop publishing PMARs under latest dirs and assign dedicated subdir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0] - 2017-11-6
+### Added
+- all partial mars are moved under new `pub/firefox/nightly/partials/YYYY/MM/{...}-{branch}` and `pub/firefox/nightly/partials/YYYY/MM/{...}-{branch}-l10n` locations
+
+### Fixed
+- locales partial mar are going under their corresponding dated l10n folder, instead of the en-US
+
+### Removed
+- stop publishing partial mars under latest directories for all locales, including `en-US`
+
 ## [3.1.0] - 2017-10-26
 ### Added
 - `PRODUCT_TO_PATH` to map `fennec` to `pub/mobile/`

--- a/beetmoverscript/templates/firefox_nightly.yml
+++ b/beetmoverscript/templates/firefox_nightly.yml
@@ -210,9 +210,7 @@ mapping:
     {{ partial }}:
       s3_key: firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
       destinations:
-        - {{ upload_date }}-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
-        - latest-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
-        - latest-{{ branch }}-l10n/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
+        - partials/{{ upload_date }}-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
       update_balrog_manifest: true
       from_buildid: {{ from_buildid }}
   {% endfor %}

--- a/beetmoverscript/templates/firefox_nightly_repacks.yml
+++ b/beetmoverscript/templates/firefox_nightly_repacks.yml
@@ -81,8 +81,7 @@ mapping:
     {{ partial }}:
       s3_key: firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
       destinations:
-        - {{ upload_date }}-{{ branch }}/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
-        - latest-{{ branch }}-l10n/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
+        - partials/{{ upload_date }}-{{ branch }}-l10n/firefox-{{ branch }}-{{ version }}-{{ platform }}-{{ locale }}-{{ from_buildid }}-{{ buildid }}.partial.mar
       update_balrog_manifest: true
       from_buildid: {{ from_buildid }}
   {% endfor %}

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
         3,
-        1,
+        2,
         0
     ],
-    "version_string": "3.1.0"
+    "version_string": "3.2.0"
 }


### PR DESCRIPTION
We've reached a resolution under [bug 1405622](https://bugzilla.mozilla.org/show_bug.cgi?id=1405622) to:

- stop publishing partial mars under latest directories for both `en-US` and `locales`
- have a dedicated subdir for these instead to ease the implementation of a lifecycle policy 
- locale partial.mar are going in the `date-branch-l10n` subdirs as opposed to `date-branch` where `en-US` lives