### PR TITLE
Bug 1336514 - Publish jsshell-*.zip

### DIFF
--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -91,7 +91,7 @@ RELEASE_ACTIONS = (
 RELEASE_EXCLUDE = (
     r"^.*tests.*$",
     r"^.*crashreporter.*$",
-    r"^.*[^k]\.zip(\.asc)?$",
+    r"^(?!.*jsshell-).*\.zip(\.asc)?$",
     r"^.*\.log$",
     r"^.*\.txt$",
     r"^.*/partner-repacks.*$",


### PR DESCRIPTION
If https://bugzilla.mozilla.org/show_bug.cgi?id=1336514#c33 gets r+ this can be "uplifted"