### PR TITLE
Add .pytest_cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
pytest 3.4.0 comes with a new folder. Let's ignore it from git. pytest did the same in https://github.com/pytest-dev/pytest/commit/ab00c3e9117e22f4a7e138cbbb5b6c8754bf3102 

