### PR TITLE
Support win64-asan-reporter and mac-asan-reporter platforms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,8 @@ This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
 .. towncrier release notes start
 
-[7.6.0] = (2018-07-11)
-----------------------
-
-Added
-~~~~~
-
--  support win64-asan-reporter and mac-asan-reporter platforms (`#1473259
-   <https://bugzilla.mozilla.org/show_bug.cgi?id=1473259>`_)
+[next] = (YYYY-MM-DD)
+---------------------
 
 [7.5.0] = (2018-07-02)
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
 .. towncrier release notes start
 
+[7.6.0] = (2018-07-11)
+----------------------
+
+Added
+~~~~~
+
+-  support win64-asan-reporter and mac-asan-reporter platforms (`#1473259
+   <https://bugzilla.mozilla.org/show_bug.cgi?id=1473259>`_)
+
 [7.5.0] = (2018-07-02)
 ----------------------
 

--- a/beetmoverscript/constants.py
+++ b/beetmoverscript/constants.py
@@ -19,10 +19,12 @@ STAGE_PLATFORM_MAP = {
     'linux64-asan-reporter': 'linux-x86_64-asan-reporter',
     'linux64-devedition': 'linux-x86_64',
     'macosx64': 'mac',
+    'macosx64-asan-reporter': 'mac-asan-reporter',
     'macosx64-devedition': 'mac',
     'win32': 'win32',
     'win32-devedition': 'win32',
     'win64': 'win64',
+    'win64-asan-reporter': 'win64-asan-reporter',
     'win64-devedition': 'win64',
 }
 

--- a/beetmoverscript/newsfragments/1473259.added
+++ b/beetmoverscript/newsfragments/1473259.added
@@ -1,0 +1,1 @@
+support win64-asan-reporter and mac-asan-reporter platforms

--- a/beetmoverscript/templates/firefox_nightly.yml
+++ b/beetmoverscript/templates/firefox_nightly.yml
@@ -175,7 +175,7 @@ mapping:
         - {{ upload_date }}-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.buildhub.json
         - latest-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.buildhub.json
         - latest-{{ branch }}-l10n/firefox-{{ version }}.{{ locale }}.{{ platform }}.buildhub.json
- {% if platform in ["linux-i686", "linux-x86_64", "linux-x86_64-asan-reporter", "mac"] %}
+ {% if platform in ["linux-i686", "linux-x86_64", "linux-x86_64-asan-reporter", "mac", "mac-asan-reporter"] %}
     mar:
       s3_key: mar
       destinations:
@@ -186,7 +186,7 @@ mapping:
       destinations:
         - {{ upload_date }}-{{ branch }}/mar-tools/{{ stage_platform }}/mbsdiff
         - latest-{{ branch }}/mar-tools/{{ stage_platform }}/mbsdiff
-  {% elif platform in ["win32", "win64"] %}
+  {% elif platform in ["win32", "win64", "win64-asan-reporter"] %}
     mar.exe:
       s3_key: mar.exe
       destinations:
@@ -212,7 +212,7 @@ mapping:
         - {{ upload_date }}-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.tar.bz2.asc
         - latest-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.tar.bz2.asc
         - latest-{{ branch }}-l10n/firefox-{{ version }}.{{ locale }}.{{ platform }}.tar.bz2.asc
-  {% elif platform in ["mac"] %}
+  {% elif platform in ["mac", "mac-asan-reporter"] %}
     target.dmg:
       s3_key: firefox-{{ version }}.{{ locale }}.{{ platform }}.dmg
       destinations:
@@ -225,7 +225,7 @@ mapping:
         - {{ upload_date }}-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.dmg.asc
         - latest-{{ branch }}/firefox-{{ version }}.{{ locale }}.{{ platform }}.dmg.asc
         - latest-{{ branch }}-l10n/firefox-{{ version }}.{{ locale }}.{{ platform }}.dmg.asc
-  {% elif platform in ["win32", "win64"] %}
+  {% elif platform in ["win32", "win64", "win64-asan-reporter"] %}
     target.stub-installer.exe:
       s3_key: installer-stub.exe
       destinations:


### PR DESCRIPTION
These changes are similar to what catlee did before for Linux to support asan-reporter.

I am currently working on Windows support in bug 1473259 but Mac support is also planned and I figured it is easier to make these changes in one on the beetmover side, so it is less work to deploy.

I am also going to change the m-c patch in that bug to match the platform descriptor used here (win64-asan-reporter).