### PR TITLE
Bug 1484932 - Update GeckoView maven group id: org.mozilla.geckoview

### DIFF
--- a/beetmoverscript/templates/maven_geckoview.yml
+++ b/beetmoverscript/templates/maven_geckoview.yml
@@ -4,7 +4,8 @@ metadata:
     description: "Maps artifacts to spec'd maven location"
     owner: "release@mozilla.com"
 
-s3_bucket_path: maven2/org/mozilla/{{ artifact_id }}/{{ version }}/  # Maven groupId is org.mozilla
+# XXX Bug 1484932: Maven groupId is org.mozilla.geckoview
+s3_bucket_path: maven2/org/mozilla/geckoview/{{ artifact_id }}/{{ version }}/
 
 mapping:
 {% for locale in ['en-US'] %}

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -148,7 +148,7 @@ def test_generate_manifest(context, mocker):
             'name': 'Maven repository',
             'owner': 'release@mozilla.com',
         },
-        's3_bucket_path': 'maven2/org/mozilla/geckoview-x86/62.0/',
+        's3_bucket_path': 'maven2/org/mozilla/geckoview/geckoview-x86/62.0/',
     }
 ), (
     '63.0b11',
@@ -212,7 +212,7 @@ def test_generate_manifest(context, mocker):
             'name': 'Maven repository',
             'owner': 'release@mozilla.com',
         },
-        's3_bucket_path': 'maven2/org/mozilla/geckoview-beta-arm64-v8a/63.0b11/',
+        's3_bucket_path': 'maven2/org/mozilla/geckoview/geckoview-beta-arm64-v8a/63.0b11/',
     }
 ), (
     '63.0a1',
@@ -276,7 +276,7 @@ def test_generate_manifest(context, mocker):
             'name': 'Maven repository',
             'owner': 'release@mozilla.com',
         },
-        's3_bucket_path': 'maven2/org/mozilla/geckoview-nightly-x86/63.0.20181231120000/',
+        's3_bucket_path': 'maven2/org/mozilla/geckoview/geckoview-nightly-x86/63.0.20181231120000/',
     }
 ), (
     '63.0b11',
@@ -340,7 +340,7 @@ def test_generate_manifest(context, mocker):
             'name': 'Maven repository',
             'owner': 'release@mozilla.com',
         },
-        's3_bucket_path': 'maven2/org/mozilla/geckoview-nightly-maple-armeabi-v7a/63.0.20181231120000/',
+        's3_bucket_path': 'maven2/org/mozilla/geckoview/geckoview-nightly-maple-armeabi-v7a/63.0.20181231120000/',
     }
 )))
 def test_generate_manifest_maven(context, mocker, version, build_id, artifact_id, expected):


### PR DESCRIPTION
Tested with https://maven-default.stage.mozaws.net/maven2/org/mozilla/geckoview/geckoview-nightly-try-x86/63.0.20180827145613/geckoview-nightly-try-x86-63.0.20180827145613.aar coming from graph 
https://treeherder.mozilla.org/#/jobs?repo=try&revision=5a4ded81f879b843e06a30e52c4598c21115f9f8&selectedJob=196109867