### PR TITLE
Fix geckoview tasks after snapshots enabled.

### DIFF
--- a/beetmoverscript/newsfragments/1493942.fixed
+++ b/beetmoverscript/newsfragments/1493942.fixed
@@ -1,0 +1,1 @@
+Bugfix in geckoview in-tree snapshot logic given declarative artifacts.

--- a/beetmoverscript/zip.py
+++ b/beetmoverscript/zip.py
@@ -198,7 +198,7 @@ def _ensure_all_expected_files_are_present_in_archive(zip_path, files_in_archive
                     file_, zip_path
                 )
             )
-        if 'SNAPSHOT' in mapping_manifest['s3_bucket_path']:
+        if mapping_manifest and 'SNAPSHOT' in mapping_manifest['s3_bucket_path']:
             (date, clock, bno) = _extract_and_check_timestamps(file_,
                                                                SNAPSHOT_TIMESTAMP_REGEX)
             _args = {


### PR DESCRIPTION
For some reason during development I assumed that all maven tasks were coming from the mobile world, hence they had the rendering template in the good old fashioned way. I totally missed that declarative artifacts changed the way we organize artifacts within in-tree as well, where on central for nightlies we have the `geckoview`. I tested this locally and this should unblock us for now. After we migrate everything to declarative artifacts, beetmoverscript tests are going to be rewritten so that we have integration tests for all possible scenarios.

CC @srfraser @lundjordan Another reason for wh we need declarative artifacts rolled-out to all products / channels 😳 