### PR TITLE
Bug 1542500 Finding the right upstream artifact

### DIFF
--- a/beetmoverscript/script.py
+++ b/beetmoverscript/script.py
@@ -319,17 +319,17 @@ async def move_beets(context, artifacts_to_beetmove, manifest=None, artifact_map
 
     for locale in artifacts_to_beetmove:
 
-        installer_path = ''
+        installer_artifact = ''
         buildhub_artifact_exists = False
         # get path of installer beet
         for artifact in artifacts_to_beetmove[locale]:
             if exists_or_endswith(artifact, INSTALLER_ARTIFACTS):
-                installer_path = artifacts_to_beetmove[locale][artifact]
+                installer_artifact = artifact
             if exists_or_endswith(artifact, BUILDHUB_ARTIFACT):
                 buildhub_artifact_exists = True
 
         # throws error if buildhub.json is present and installer isn't
-        if not installer_path and buildhub_artifact_exists:
+        if not installer_artifact and buildhub_artifact_exists:
             raise ScriptWorkerTaskException(
                 "could not determine installer path from task payload"
             )
@@ -343,8 +343,13 @@ async def move_beets(context, artifacts_to_beetmove, manifest=None, artifact_map
             # in logical coding terms, this means that if installer_path is an empty
             # string, then this if-block is never reached
             if exists_or_endswith(artifact, BUILDHUB_ARTIFACT):
-                write_json(source, get_updated_buildhub_artifact(
-                    source, installer_path, context, locale, manifest=manifest, artifact_map=artifact_map))
+                write_json(source,
+                           get_updated_buildhub_artifact(
+                               path=source, installer_artifact=installer_artifact,
+                               installer_path=artifacts_to_beetmove[locale][installer_artifact],
+                               context=context, locale=locale,
+                               manifest=manifest, artifact_map=artifact_map)
+                           )
 
             if artifact_map:
                 task_id = get_taskId_from_full_path(source)

--- a/beetmoverscript/task.py
+++ b/beetmoverscript/task.py
@@ -188,20 +188,19 @@ def update_props(context, props, platform_mapping):
     return props
 
 
-def get_updated_buildhub_artifact(path, installer_path, context, locale, manifest=None, artifact_map=None):
+def get_updated_buildhub_artifact(path, installer_artifact, installer_path, context, locale, manifest=None, artifact_map=None):
     """
     Read the file into a dict, alter the fields below, and return the updated dict
     buildhub.json fields that should be changed: download.size, download.date, download.url
     """
     contents = utils.load_json(path)
-    installer_name = os.path.basename(installer_path)
     url_prefix = context.config["bucket_config"][context.bucket]["url_prefix"]
     if artifact_map:
         task_id = get_taskId_from_full_path(installer_path)
-        cfg = utils.extract_file_config_from_artifact_map(artifact_map, installer_name, task_id, locale)
+        cfg = utils.extract_file_config_from_artifact_map(artifact_map, installer_artifact, task_id, locale)
         path = urllib.parse.quote(cfg['destinations'][0])
     else:
-        dest = manifest['mapping'][locale][installer_name]['destinations'][0]
+        dest = manifest['mapping'][locale][installer_artifact]['destinations'][0]
         path = urllib.parse.quote(urllib.parse.urljoin(manifest["s3_bucket_path"], dest))
     url = urllib.parse.urljoin(url_prefix, path)
 

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -688,14 +688,18 @@ def test_extract_file_config_from_artifact_map_raises(task_id, locale, filename)
             task_def['payload']['artifactMap'], filename, task_id, locale)
 
 
-@pytest.mark.parametrize("path,found", ((
-    "buildhub.json", 'buildhub.json'
+@pytest.mark.parametrize("path,locale,found", ((
+    "buildhub.json", 'en-US', 'buildhub.json'
 ), (
-    'foobar', None
+    "buildhub.json", 'en-GB', None
+), (
+    'foobar', 'en-GB', None
+), (
+    'foobar', 'en-US', None
 )))
-def test_extract_full_artifact_map_path(path, found):
+def test_extract_full_artifact_map_path(path, locale, found):
     task_def = get_fake_valid_task(taskjson='task_artifact_map.json')
-    assert extract_full_artifact_map_path(task_def['payload']['artifactMap'], path) == found
+    assert extract_full_artifact_map_path(task_def['payload']['artifactMap'], path, locale) == found
 
 
 @pytest.mark.parametrize("filename, basenames, expected", ((

--- a/beetmoverscript/test/test_utils.py
+++ b/beetmoverscript/test/test_utils.py
@@ -16,6 +16,7 @@ from beetmoverscript.utils import (generate_beetmover_manifest, get_hash,
                                    is_partner_private_task, is_partner_public_task,
                                    _check_locale_consistency, validated_task_id,
                                    extract_file_config_from_artifact_map,
+                                   extract_full_artifact_map_path,
                                    exists_or_endswith)
 from beetmoverscript.constants import (
     HASH_BLOCK_SIZE, INSTALLER_ARTIFACTS,
@@ -685,6 +686,16 @@ def test_extract_file_config_from_artifact_map_raises(task_id, locale, filename)
     with pytest.raises(TaskVerificationError):
         extract_file_config_from_artifact_map(
             task_def['payload']['artifactMap'], filename, task_id, locale)
+
+
+@pytest.mark.parametrize("path,found", ((
+    "buildhub.json", 'buildhub.json'
+), (
+    'foobar', None
+)))
+def test_extract_full_artifact_map_path(path, found):
+    task_def = get_fake_valid_task(taskjson='task_artifact_map.json')
+    assert extract_full_artifact_map_path(task_def['payload']['artifactMap'], path) == found
 
 
 @pytest.mark.parametrize("filename, basenames, expected", ((

--- a/beetmoverscript/test/test_work_dir/cot/eSzfNqMZT_mSiQQXu8hyqg/public/build/buildhub.json
+++ b/beetmoverscript/test/test_work_dir/cot/eSzfNqMZT_mSiQQXu8hyqg/public/build/buildhub.json
@@ -9,10 +9,10 @@
         "target": "i686-pc-linux-gnu"
     },
     "download": {
-        "date": "2018-11-13T16:34:34.968510+00:00",
+        "date": "2019-04-08T10:19:18.761418+00:00",
         "mimetype": "application/octet-stream",
         "size": 7201,
-        "url": "https://archive.test/https%3A/archive.test/pub/mobile/nightly/2016/09/2016-09-01-16-26-14-mozilla-central-fake/en-US/fake-99.0a1.en-US.target.apk"
+        "url": "https://archive.test/pub/mobile/nightly/2016/09/2016-09-01-16-26-14-mozilla-central-fake/en-US/fake-99.0a1.en-US.target.apk"
     },
     "source": {
         "product": "firefox",

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -318,22 +318,8 @@ def exists_or_endswith(filename, basenames):
     return False
 
 
-def extract_full_artifact_map_path(artifact_map, basepath):
-    """The way artifact map is build allows both `public/build/target.apk` but
-    also `public/build/en-US/target.dmg` depending on platform/product. In order
-    to solve this, given the basename of the installer artifact, we iterate in
-    the artifact_map searching for the correct name to use.
-
-    If no path is found, it returns `None` naturally."""
-    for entry in artifact_map:
-        for path in entry['paths']:
-            if path.endswith(basepath):
-                return path
-
-
-def extract_file_config_from_artifact_map(artifact_map, basepath, task_id, locale):
+def extract_file_config_from_artifact_map(artifact_map, path, task_id, locale):
     """Return matching artifact map config."""
-    path = extract_full_artifact_map_path(artifact_map, basepath)
     for entry in artifact_map:
         if entry['taskId'] != task_id or entry['locale'] != locale:
             continue

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -318,6 +318,16 @@ def exists_or_endswith(filename, basenames):
     return False
 
 
+def extract_full_artifact_map_path(artifact_map, basepath):
+    """Find the artifact map entry from the given path.
+
+    If no path is found, it returns `None` naturally."""
+    for entry in artifact_map:
+        for path in entry['paths']:
+            if path.endswith(basepath):
+                return path
+
+
 def extract_file_config_from_artifact_map(artifact_map, path, task_id, locale):
     """Return matching artifact map config."""
     for entry in artifact_map:

--- a/beetmoverscript/utils.py
+++ b/beetmoverscript/utils.py
@@ -318,11 +318,11 @@ def exists_or_endswith(filename, basenames):
     return False
 
 
-def extract_full_artifact_map_path(artifact_map, basepath):
-    """Find the artifact map entry from the given path.
-
-    If no path is found, it returns `None` naturally."""
+def extract_full_artifact_map_path(artifact_map, basepath, locale):
+    """Find the artifact map entry from the given path."""
     for entry in artifact_map:
+        if entry['locale'] != locale:
+            continue
         for path in entry['paths']:
             if path.endswith(basepath):
                 return path


### PR DESCRIPTION
In order to translate the full local scriptworker path into an artifact, we
were using `os.path.basename` and then searching through the artifact map,
ignoring locales. This caused the first match to be returned, whether or not it
was correct.

This new variant passes in both the full local path and the upstream artifact
path, so we can match against the full artifact path instead, removing a chance
of duplicate matches.